### PR TITLE
Ensure CSV writer flushes header and handles errors

### DIFF
--- a/pkg/csv/writer.go
+++ b/pkg/csv/writer.go
@@ -18,8 +18,15 @@ func NewWriter(file string, header []string) (*Writer, error) {
 		return nil, err
 	}
 	writer := csv.NewWriter(f)
-	err = writer.Write(header)
-	if err != nil {
+	if err = writer.Write(header); err != nil {
+		// ensure resources are released on failure
+		writer.Flush()
+		_ = f.Close()
+		return nil, err
+	}
+	writer.Flush()
+	if err = writer.Error(); err != nil {
+		_ = f.Close()
 		return nil, err
 	}
 	return &Writer{header: header, autoFlush: false, file: f, writer: writer}, nil

--- a/pkg/csv/writer_test.go
+++ b/pkg/csv/writer_test.go
@@ -1,0 +1,28 @@
+package csv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewWriterWritesHeader(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "test.csv")
+	w, err := NewWriter(file, []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("NewWriter returned error: %v", err)
+	}
+	// header should be flushed immediately
+	content, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+	expected := "a,b\n"
+	if string(content) != expected {
+		t.Fatalf("unexpected content: got %q, want %q", string(content), expected)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- flush and verify header write in CSV writer, closing file if an error occurs
- add unit test confirming header is written immediately

## Testing
- `go test ./pkg/csv -run TestNewWriterWritesHeader -count=1 -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895fc97d6a88332b6c9fb8561099d15