### PR TITLE
docs: fix typo in build section

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ $ ./egovchecker defaultconfig
 
 ## Build
 ### Go Build
-다음과 같이 빌드 스크립트를 통해 븰드를 수행할 수 있습니다.
+다음과 같이 빌드 스크립트를 통해 빌드를 수행할 수 있습니다.
 ```shell
 $ ./build_with_flags.sh -o egovchecker
 ```


### PR DESCRIPTION
## Summary
- fix Korean typo in Go build instructions of README (븰드 -> 빌드)

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896039477088332b35e33546b38bdf9