### PR TITLE
Fix EntityManager typo in config and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ superClasses = JpaRepository,CrudRepository,PagingAndSortingRepository
 
 [repository.hibernate]
 classAnnotations = @Repository
-fieldTypes = HibernateTemplate,EntityManger,EntityManagerFactory,Session,SessionFactory
+fieldTypes = HibernateTemplate,EntityManager,EntityManagerFactory,Session,SessionFactory
 ```
 Ini 파일 설정은 3개의 세션(`controller`, `service`, `repository`)과 
 `repository` 세션 밑에 5개의 하위 세션(`repository.ibatis`, `repository.mybatis`, `repository.mapper`, `repository.jpa`, `repository.hibernate`)로 구성되어 있습니다.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ func setDefaultValues() {
 	viper.SetDefault("repository.jpa.superClasses", "JpaRepository,CrudRepository,PagingAndSortingRepository")
 
 	viper.SetDefault("repository.hibernate.classAnnotations", "@Repository")
-	viper.SetDefault("repository.hibernate.fieldTypes", "HibernateTemplate,EntityManger,EntityManagerFactory,Session,SessionFactory")
+        viper.SetDefault("repository.hibernate.fieldTypes", "HibernateTemplate,EntityManager,EntityManagerFactory,Session,SessionFactory")
 }
 
 func getWorkingDirectory() string {

--- a/internal/config/assets/config.ini
+++ b/internal/config/assets/config.ini
@@ -33,4 +33,4 @@ superClasses = JpaRepository,CrudRepository,PagingAndSortingRepository
 
 [repository.hibernate]
 classAnnotations = @Repository
-fieldTypes = HibernateTemplate,EntityManger,EntityManagerFactory,Session,SessionFactory
+fieldTypes = HibernateTemplate,EntityManager,EntityManagerFactory,Session,SessionFactory


### PR DESCRIPTION
## Summary
- fix `EntityManager` field types typo in config and README
- correct default Hibernate `fieldTypes` value in `root.go`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896044d7edc8332b0ca8c5afe28634e