### PR TITLE
v0.6 main 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,14 +177,14 @@ $ ./egovchecker inspect -t ./test/sample -p egovframework -o
 	    "package_name": "com.egovframe.sample.service.service.impl",
 	    "class_name": "SampleDAO",
 	    "violation": "데이터 액세스 규칙 미준수입니다.",
-	    "description": "EgovAbstractDAO 또는 EgovAbstractMapper 클래스를 상속하거나, @Mapper 어노테이션 지정 또는 JPA/Hibernate가 활용되어야 합니다. "
+	    "description": "EgovAbstractDAO 또는 EgovAbstractMapper 클래스를 상속하거나, @Mapper/@EgovMapper 어노테이션 지정 또는 JPA/Hibernate가 활용되어야 합니다. "
 	  },
     {
 	    "file_path": "sample/com/egovframe/sample/service/impl/SampleRepository.java",
 	    "package_name": "com.egovframe.sample.service.service.impl",
 	    "class_name": "SampleRepository",
 	    "violation": "데이터 액세스 규칙 미준수입니다.",
-	    "description": "EgovAbstractDAO 또는 EgovAbstractMapper 클래스를 상속하거나, @Mapper 어노테이션 지정 또는 JPA/Hibernate가 활용되어야 합니다. "
+	    "description": "EgovAbstractDAO 또는 EgovAbstractMapper 클래스를 상속하거나, @Mapper/@EgovMapper 어노테이션 지정 또는 JPA/Hibernate가 활용되어야 합니다. "
 	  }
   ]
 }

--- a/cmd/ver/ver.go
+++ b/cmd/ver/ver.go
@@ -24,13 +24,19 @@ import "fmt"
 //   - 설정 상 EntityManager 필드 클래스 오류 수정
 //   - Check List 처리 오류 수정 등
 //
-// v0.5 : 
+// v0.5 :
 //   - eGovFrame v5.0 점검 기준 추가
 //   - 점검 결과 JSON 저장 옵션 추가
 //   - Java grammar 업데이트 (Java 24 지원)
 //   - Spring Data JPA 관련 체크 추가
 //   - 점검 결과 출력 보완 (Layer별 세부 위반 리스트를 결과 아래로 조정)
-const CheckerVersion = "v0.5"
+//
+// v0.6 :
+//
+//   - CSV 결과 파일에 @EgovMapper 정보 추가
+//   - Annotation 클래스에 대한 Class 이름 미식별 오류 수정 및 점검 조건 처리 추가
+//   - Spring Data JPA의 Repository 클래스에 대한 점검 보완 (@Repository 미지정 식별)
+const CheckerVersion = "v0.6"
 
 // build flags
 var (

--- a/internal/examine/controller/controller.go
+++ b/internal/examine/controller/controller.go
@@ -61,6 +61,12 @@ func Examine(files []string, streamer *json.Streamer) (err error) {
 		classResult, _ := common.CheckClassAnnotations("controller", listener)
 		methodResult := common.CheckMethodAnnotations("controller", listener)
 
+		if listener.IsAnnotationType {
+			logList = append(logList, fmt.Sprintf("%s- Controller(%s) excluded because it's an annotation type.%s\n",
+				c.Yellow, listener.ClassName, c.Reset))
+			continue
+		}
+
 		total++
 		target := common.FormatClassName(listener.ClassName, f)
 		record := []string{target}

--- a/internal/examine/repository/jpa/jpa.go
+++ b/internal/examine/repository/jpa/jpa.go
@@ -5,12 +5,13 @@ import (
 	"github.com/switchover/eGovFrameChecker/pkg/java"
 )
 
-func Examine(listener *java.Listener) (result bool) {
-	result, _ = common.CheckClassAnnotations("repository.jpa", listener)
+func Examine(listener *java.Listener) (result bool, isRepository bool) {
+	result, _ = common.CheckExtendsInterface("repository.jpa", listener)
 	if !result {
 		return
 	}
+	isRepository = true
 
-	result, _ = common.CheckExtendsInterface("repository.jpa", listener)
+	result, _ = common.CheckClassAnnotations("repository.jpa", listener)
 	return
 }

--- a/internal/examine/repository/mapper/mapper.go
+++ b/internal/examine/repository/mapper/mapper.go
@@ -1,17 +1,20 @@
 package mapper
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/switchover/eGovFrameChecker/internal/examine/common"
 	"github.com/switchover/eGovFrameChecker/pkg/java"
 )
 
-func Examine(listener *java.Listener) (result bool) {
+func Examine(listener *java.Listener) (result bool, superClassName string) {
 	result, annotation := common.CheckClassAnnotations("repository.mapper", listener)
 	if !result {
 		return
 	}
+
+	superClassName = fmt.Sprintf("<%s>", annotation)
 
 	if strings.HasPrefix(annotation, "@") {
 		annotation = annotation[1:]

--- a/internal/examine/repository/repository.go
+++ b/internal/examine/repository/repository.go
@@ -157,9 +157,8 @@ func check(f string) (result bool, listener *java.Listener, superClassName strin
 		return
 	}
 
-	result = mapper.Examine(listener)
+	result, superClassName = mapper.Examine(listener)
 	if result {
-		superClassName = "<@Mapper>"
 		return
 	}
 

--- a/internal/examine/repository/repository.go
+++ b/internal/examine/repository/repository.go
@@ -61,6 +61,12 @@ func Examine(files []string, streamer *json.Streamer) (err error) {
 			continue
 		}
 
+		if !result && listener.IsAnnotationType {
+			logList = append(logList, fmt.Sprintf("%s- Repository(%s) excluded because it's an annotation type.%s\n",
+				c.Yellow, listener.ClassName, c.Reset))
+			continue
+		}
+
 		total++
 		target := common.FormatClassName(listener.ClassName, f)
 		record := []string{target}

--- a/internal/examine/repository/repository.go
+++ b/internal/examine/repository/repository.go
@@ -30,7 +30,7 @@ func Examine(files []string, streamer *json.Streamer) (err error) {
 	var writer *csv.Writer
 	if output {
 		writer, err = csv.NewWriter("repositories.csv",
-			[]string{"Total list (*DAO.java or *Mapper.java)", "Extends EgovAbstract* or Use @Mapper", "Super Class"})
+			[]string{"Total list (*DAO.java or *Mapper.java)", "Extends EgovAbstract* or Use @Mapper/@EgovMapper", "Super Class"})
 		if err != nil {
 			return err
 		}
@@ -46,7 +46,7 @@ func Examine(files []string, streamer *json.Streamer) (err error) {
 		}
 
 		superClassName := ""
-		result, listener, superClassName, err := check(f)
+		result, listener, superClassName, isRepository, err := check(f)
 		if err != nil {
 			if skipFileError {
 				log.Printf("Failed to examine file but skipped: %v\n", err)
@@ -55,7 +55,7 @@ func Examine(files []string, streamer *json.Streamer) (err error) {
 			return err
 		}
 
-		if !result && listener.IsInterface && len(listener.ClassAnnotations) == 0 {
+		if !result && !isRepository && listener.IsInterface && len(listener.ClassAnnotations) == 0 {
 			logList = append(logList, fmt.Sprintf("%s- Repository(%s) excluded because it's a simple interface.%s\n",
 				c.Yellow, listener.ClassName, c.Reset))
 			continue
@@ -138,7 +138,7 @@ func Examine(files []string, streamer *json.Streamer) (err error) {
 	return
 }
 
-func check(f string) (result bool, listener *java.Listener, superClassName string, err error) {
+func check(f string) (result bool, listener *java.Listener, superClassName string, isRepository bool, err error) {
 	data, err := os.ReadFile(f)
 	if err != nil {
 		return
@@ -168,7 +168,7 @@ func check(f string) (result bool, listener *java.Listener, superClassName strin
 		return
 	}
 
-	result = jpa.Examine(listener)
+	result, isRepository = jpa.Examine(listener)
 	if result {
 		superClassName = "<JPA>"
 		return

--- a/internal/examine/service/service.go
+++ b/internal/examine/service/service.go
@@ -68,6 +68,12 @@ func Examine(files []string, streamer *json.Streamer) (err error) {
 			continue
 		}
 
+		if listener.IsAnnotationType {
+			logList = append(logList, fmt.Sprintf("%s- Service(%s) excluded because it's an annotation type.%s\n",
+				c.Yellow, listener.ClassName, c.Reset))
+			continue
+		}
+
 		total++
 		target := common.FormatClassName(listener.ClassName, f)
 		record := []string{target}

--- a/internal/i18n/messages/messages.json
+++ b/internal/i18n/messages/messages.json
@@ -38,7 +38,7 @@
     "DAO001": {
       "code": "DAO001",
       "message": "Data-access rule is not satisfied.",
-      "description": "The class must extend EgovAbstractDAO or EgovAbstractMapper, specify the @Mapper annotation, or use JPA/Hibernate."
+      "description": "The class must extend EgovAbstractDAO or EgovAbstractMapper, specify the @Mapper/@EgovMapper annotation, or use JPA/Hibernate."
     }
   }
 }

--- a/internal/i18n/messages/messages_ko.json
+++ b/internal/i18n/messages/messages_ko.json
@@ -38,7 +38,7 @@
     "DAO001": {
       "code": "DAO001",
       "message": "데이터 액세스 규칙 미준수입니다.",
-      "description": "EgovAbstractDAO 또는 EgovAbstractMapper 클래스를 상속하거나, @Mapper 어노테이션 지정 또는 JPA/Hibernate가 활용되어야 합니다. "
+      "description": "EgovAbstractDAO 또는 EgovAbstractMapper 클래스를 상속하거나, @Mapper/@EgovMapper 어노테이션 지정 또는 JPA/Hibernate가 활용되어야 합니다. "
     }
   }
 }

--- a/pkg/java/java.go
+++ b/pkg/java/java.go
@@ -15,6 +15,7 @@ type Listener struct {
 	PackageName       string
 	ClassName         string
 	IsInterface       bool
+	IsAnnotationType  bool
 	SuperClassName    string
 	HasImplementation bool
 	ClassAnnotations  []string
@@ -139,6 +140,25 @@ func (l *Listener) EnterInterfaceDeclaration(ctx *parser.InterfaceDeclarationCon
 }
 
 func (l *Listener) ExitInterfaceDeclaration(_ *parser.InterfaceDeclarationContext) {
+	if l.isInnerClass {
+		l.isInnerClass = false
+		return
+	}
+	l.currentClass = ""
+}
+
+func (l *Listener) EnterAnnotationTypeDeclaration(ctx *parser.AnnotationTypeDeclarationContext) {
+	if l.currentClass != "" { // inner class
+		l.isInnerClass = true
+		return
+	}
+	l.initialize()
+	l.ClassName = ctx.Identifier().GetText()
+	l.IsAnnotationType = true
+	l.currentClass = l.ClassName
+}
+
+func (l *Listener) ExitAnnotationTypeDeclaration(_ *parser.AnnotationTypeDeclarationContext) {
 	if l.isInnerClass {
 		l.isInnerClass = false
 		return

--- a/test/sample/src/main/java/egovframework/example/cmmn/CommonMapper.java
+++ b/test/sample/src/main/java/egovframework/example/cmmn/CommonMapper.java
@@ -1,0 +1,9 @@
+package egovframework.example.cmmn;
+
+import java.lang.annotation.*;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(value = ElementType.TYPE)
+public @interface CommonMapper {
+    String value() default "";
+}

--- a/test/sample/src/main/java/egovframework/example/sample/service/impl/SampleEntity.java
+++ b/test/sample/src/main/java/egovframework/example/sample/service/impl/SampleEntity.java
@@ -1,0 +1,16 @@
+package egovframework.example.sample.service.impl;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "samples")
+public class SampleEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    // Getters, Setters, Constructors
+}

--- a/test/sample/src/main/java/egovframework/example/sample/service/impl/SampleRepository.java
+++ b/test/sample/src/main/java/egovframework/example/sample/service/impl/SampleRepository.java
@@ -1,10 +1,11 @@
 package egovframework.example.sample.service.impl;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 //@Repository
-public interface SampleRepository extends JpaRepository<MemberEntity, Long> {
+public interface SampleRepository extends JpaRepository<SampleEntity, Long> {
     // 쿼리 메서드 자동 생성 예시
-    List<Member> findByName(String name);
+    List<SampleEntity> findByName(String name);
 }

--- a/test/sample/src/main/java/egovframework/example/sample/service/impl/SampleRepository.java
+++ b/test/sample/src/main/java/egovframework/example/sample/service/impl/SampleRepository.java
@@ -1,0 +1,10 @@
+package egovframework.example.sample.service.impl;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+//@Repository
+public interface SampleRepository extends JpaRepository<MemberEntity, Long> {
+    // 쿼리 메서드 자동 생성 예시
+    List<Member> findByName(String name);
+}


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to the handling and inspection of Java annotation types, especially for repository and service layer checks. It also expands support for custom mapper annotations and enhances output clarity in both logs and CSV reports. The most important changes are summarized below:

**Annotation Type Handling and Exclusion:**

* Added support for detecting Java annotation type declarations (`@interface`) by introducing the `IsAnnotationType` field in the `Listener` struct and updating the Java parser logic to set this field appropriately. This ensures that annotation types are accurately identified during code inspection. [[1]](diffhunk://#diff-73e53b8e3a00c10c52b35c9e4191887486c59731a5413408a48d02bfc3819fe1R18) [[2]](diffhunk://#diff-73e53b8e3a00c10c52b35c9e4191887486c59731a5413408a48d02bfc3819fe1R150-R168)
* Updated repository, service, and controller inspection logic to exclude annotation types from violation checks and to add informative log messages when such exclusions occur. [[1]](diffhunk://#diff-a988bfab4840a94c0dcf05a4ed9fd402199a87eae1842748aa0bea1c69ec5c27L58-R69) [[2]](diffhunk://#diff-1e7e7e801534cea913cdf34a666479c1ac4c46703ad8becb1cd80b0d156a279bR71-R76) [[3]](diffhunk://#diff-01f484726be5d7463d1ff5f1fd5df35487a28472c11ab551d816be08c9da1077R64-R69)

**Repository and Mapper Rule Enhancements:**

* Improved repository and mapper examination functions to better distinguish between different repository types, including custom mappers and JPA repositories. Now, the checks return additional context (such as whether a class is a repository and the annotation used), and the CSV output includes both `@Mapper` and `@EgovMapper` as valid annotations. [[1]](diffhunk://#diff-76e0734585f9d5c5587b4f39ea869a6a9f595384559bfd86e5ed89037c92c28cR4-R18) [[2]](diffhunk://#diff-4ef4f5e9a696e21d45213574c40e5434bed6fa40aab5853f22c94a34bdc8bdbfL8-R15) [[3]](diffhunk://#diff-a988bfab4840a94c0dcf05a4ed9fd402199a87eae1842748aa0bea1c69ec5c27L49-R49) [[4]](diffhunk://#diff-a988bfab4840a94c0dcf05a4ed9fd402199a87eae1842748aa0bea1c69ec5c27L135-R141) [[5]](diffhunk://#diff-a988bfab4840a94c0dcf05a4ed9fd402199a87eae1842748aa0bea1c69ec5c27L160-R171) [[6]](diffhunk://#diff-a988bfab4840a94c0dcf05a4ed9fd402199a87eae1842748aa0bea1c69ec5c27L33-R33)

**Documentation and Internationalization Updates:**

* Updated violation messages and documentation in both Korean and English to include `@EgovMapper` as a valid annotation for data-access rule compliance. [[1]](diffhunk://#diff-432fbba29aa4cb022283348ae9ab3db62a3b87336555df64a8026dab2fb17b1eL41-R41) [[2]](diffhunk://#diff-4ea4830086cc129f93bd0d7261bff339c1380636b5d1c668f672deb77ae0ed63L41-R41) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L180-R187)

**Versioning and Sample Code:**

* Bumped the checker tool version to `v0.6` and documented the new features and fixes in the version history.
* Added new sample Java files to demonstrate custom annotation and JPA entity/repository usage. [[1]](diffhunk://#diff-b5ad77a6cda702a6086581b1564c238082974070a8ff0b7738c8bb6cd5124d8bR1-R9) [[2]](diffhunk://#diff-c907ca4345412fdf3b857cd10af4e1ab7b28095af60f57adbb28391229e9bc24R1-R16) [[3]](diffhunk://#diff-d09424f96ca5b1bb023f48c78bb9ef11c80bd959bceed12c2c3136862e6d9458R1-R11)